### PR TITLE
docs(processes): add issue template and processs docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard_issue.md
+++ b/.github/ISSUE_TEMPLATE/standard_issue.md
@@ -1,0 +1,42 @@
+---
+name: Standard issue
+about: Use this template for feature requests, tasks or bugs that will lead to a PR
+---
+
+**Title (required)**: type: short summary
+- Use one of: `bug`, `feature`, `task`, `docs`, `chore`, `infra`
+- Example: `feature: add retry logic to API client`
+
+## Summary
+A short description of the problem or requested change (one or two lines).
+
+## Motivation / Use case
+Explain why this change is needed and the user impact.
+
+## Proposal / Steps to reproduce (for bugs)
+- Steps to reproduce (for bugs):
+  1. 
+  2. 
+- Expected behavior:
+- Actual behavior:
+
+## Proposed solution (for features / tasks)
+Describe the proposed change and high-level design. Mention affected areas, files or modules.
+
+## How to test
+Provide steps to test the change locally or in CI (commands, fixtures, etc.).
+
+## Impact / Breaking changes
+Note whether this introduces a breaking change. If yes, clearly describe required migration steps.
+
+## Checklist (required before opening a PR)
+- [ ] Issue follows the `type: short summary` title format
+- [ ] Tests added / updated (unit / integration as appropriate)
+- [ ] Linter passes locally (run project's linter)
+- [ ] Documentation updated (docs/ and/or README updated accordingly)
+- [ ] I will open a PR referencing this issue and follow the PR template
+- [ ] Assign an appropriate label (bug/feature/docs/chore/infra)
+- [ ] Link this issue to a Project card (if applicable)
+- [ ] Assign reviewers or CODEOWNERS as appropriate
+
+> Notes: This repository uses Conventional Commits for PR/merge messages (types in English). The default language for documentation and PR descriptions is English. If the change is a security issue, use the security template (private report) as instructed in `SECURITY.md`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of Conduct
 
-Todos os contribuidores devem seguir regras básicas de respeito e profissionalismo.
+All contributors are expected to follow basic rules of respect and professionalism.
 
-- Seja respeitoso e inclusivo.
-- Não seja ofensivo, discriminatório ou ameaçador.
+- Be respectful and inclusive.
+- Do not be offensive, discriminatory, or threatening.
 
-Reportar comportamento inapropriado para os mantenedores através do canal indicado em `SECURITY.md`.
+Report inappropriate behavior to the maintainers via the contact channel described in `SECURITY.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,16 @@
 # Contributing to guia-github
 
-Obrigado por querer contribuir! Siga este fluxo mínimo:
+Thanks for wanting to contribute! Please follow this minimal workflow:
 
-1. Fork ou crie uma branch no repositório (`feature/<ticket>-descrição`).
-2. Use Conventional Commits (ex: `feat:`, `fix:`, `chore:`). Consulte `docs/commits.md` para o guia detalhado (mensagens em português, exceto o type).
-3. Adicione testes quando relevante e atualize documentação.
-4. Abra uma PR descrevendo o contexto, link para issue (se houver) e checklist de verificação.
+1. Fork or create a branch in the repository (`feature/<ticket>-description`).
+2. Use Conventional Commits (e.g.: `feat:`, `fix:`, `chore:`). See `docs/commits.md` for the full guide (English is the default language).
+3. Add tests where relevant and update documentation.
+4. Open a PR describing the context, link to the issue if any, and include a verification checklist.
 
-Para questões de segurança, veja `SECURITY.md`.
+PR checklist (suggested):
+- [ ] Tests executed
+- [ ] Linter OK
+- [ ] Documentation updated
+- [ ] Someone reviewed
+
+For security issues, see `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # guia-github
 
-## Objetivo
-Reunir boas práticas, templates e exemplos práticos para o uso profissional do GitHub (Actions, Projects, Issues, Branches) com foco em projetos Python.
+## Purpose
+Collect best practices, templates and practical examples for professional GitHub usage (Actions, Projects, Issues, Branching), focused on Python projects.
 
-## Licença
-MIT — veja `LICENSE`.
+## License
+MIT — see `LICENSE`.
 
-## Índice
+## Contents
 - **Docs**
-  - `docs/commits.md` — Guia de mensagens de commit
+  - `docs/commits.md` — Commit message guide
+  - `docs/processes.md` — Issue / PR / Merge process
 
-- **Exemplos**
-  - `examples/commit-templates.md` — Modelos de mensagens de commit
+- **Examples**
+  - `examples/commit-templates.md` — Commit message templates
+  - `examples/manual_dispatch.md` — How to run manual workflows
 
-## Como usar
-- Leia os arquivos em `docs/` para entender políticas e convenções.
-- Use `examples/` para testar workflows e templates diretamente no GitHub.
+## How to use
+- Read the files in `docs/` to learn policies and conventions.
+- Use the `examples/` folder to test workflows and templates directly on GitHub.
 
-## Contribuindo
-Veja `CONTRIBUTING.md` para instruções de contribuição e `CODE_OF_CONDUCT.md` para o comportamento esperado.
+## Contributing
+See `CONTRIBUTING.md` for contribution instructions and `CODE_OF_CONDUCT.md` for expected behavior.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security policy
 
-Se você encontrar uma vulnerabilidade de segurança, por favor:
-1. Envie um email para `pedroiff0@gmail.com` com detalhes e steps para reproduzir.
-2. Inclua versão, impacto e possíveis mitigations.
+If you discover a security vulnerability, please:
+1. Email `pedroiff0@gmail.com` with details and steps to reproduce the issue.
+2. Include affected versions, impact and suggested mitigations.
 
-Não divulgue publicamente a vulnerabilidade até que os mantenedores tenham tido a chance de avaliar e mitigar o problema.
+Do not publicly disclose the vulnerability until maintainers have had time to assess and mitigate it.

--- a/docs/processes.md
+++ b/docs/processes.md
@@ -1,0 +1,118 @@
+# Process Standard: Issues, Pull Requests and Merges
+
+This document defines a lightweight, practical standard for opening **Issues**, **Pull Requests (PRs)** and performing **Merges** in this repository. The goal is to reduce friction for contributors and ensure consistency for automations (labels, projects, changelog).
+
+---
+
+## 1) Issue pattern
+- **Title**: `type: short summary` — where `type` can be `bug`, `feature`, `docs`, `chore`, `infra`.
+  - Ex.: `bug: failure loading config on Python 3.11`
+- **Minimum template** (use `.github/ISSUE_TEMPLATE/`):
+  - Summary (one line)
+  - Environment (version, OS, stack)
+  - Steps to reproduce
+  - Actual / expected result
+  - Logs or relevant output
+  - Priority / Severity (optional)
+
+- **Initial labels**: assign `bug|enhancement|docs|help wanted|good first issue|priority:high` as appropriate.
+- **Project / Milestone**: link the issue to a Project card and optionally a Milestone.
+- **Assignee**: maintainer responsible (if known).
+
+> Note: For security issues, use the `security.md` template and follow `SECURITY.md` (report privately if needed).
+
+---
+
+## 2) Pull Request pattern
+- **PR title**: keep it short and descriptive. Recommended to use Conventional Commit style in the PR title (e.g., `feat(auth): add token rotation`).
+- **PR body** (use `PULL_REQUEST_TEMPLATE.md`): always include
+  - Short description of what was done
+  - Why (motivation / context)
+  - How to test (manual steps / scripts / commands)
+  - Checklist (minimum):
+    - [ ] Tests added/updated
+    - [ ] Linter OK
+    - [ ] Docs updated (if applicable)
+    - [ ] CI passed
+  - Related issue: `Closes #n` when the PR will close an issue
+- **Review**:
+  - Request at least one reviewer; `CODEOWNERS` may assign reviewers automatically.
+  - Use Draft PRs for work in progress.
+- **Labels**: apply relevant labels (e.g., `enhancement`, `breaking change`, `needs review`).
+
+---
+
+## 3) Branching / Naming
+- Recommended naming:
+  - `feature/<ticket>-description` or `feat/<ticket>-description`
+  - `fix/<ticket>-description`
+  - `docs/<description>`
+  - `chore/<description>`
+- Keep branches short (one logical unit per branch).
+
+---
+
+## 4) Merge strategy
+- **Recommended (default)**: **Squash and merge** for feature and docs PRs — produces a clean single commit on `main` and simplifies changelogs.
+- **Alternative**: **Rebase and merge** to preserve atomic commits.
+- **Merge commit**: use only for releases or complex integrations when explicit history is useful.
+- **After merge**: delete remote branch (available via merge UI), move Project card to Done, and close related issue if applicable.
+
+**Suggested squash commit message:** `type(scope): subject — Closes #12`.
+
+---
+
+## 5) What a good merge/PR message contains
+- Short summary (type/scope/operation)
+- If applicable, `Closes #n` to automatically close the issue
+- Migration notes when there are BREAKING CHANGES
+
+---
+
+## 6) Example — Issue
+**Title:** `bug: error validating token in production`
+**Body:**
+- Environment: Python 3.11, Ubuntu 22.04
+- Steps: ...
+- Expected: ...
+- Actual: ...
+
+---
+
+## 7) Example — PR
+**Title:** `fix(auth): handle refresh for expired token`
+**Body:**
+- Description: Fixes exception when trying to refresh an already expired token.
+- Tests: Unit tests added for `refresh_token`.
+- How to test:
+  - `pytest tests/test_auth.py::test_refresh_expired`
+- Checklist:
+  - [x] Tests
+  - [x] Lint
+  - [x] Docs (README updated)
+
+---
+
+## 8) Recommended automations
+- **Labeler**: apply labels based on path (`docs/**` -> `docs`, `*.py` -> `enhancement/test`).
+- **Stale bot**: close issues with no activity after X days.
+- **CI checks**: require CI success before merge.
+- **Project automations**: move cards on PR open/merge.
+
+---
+
+## 9) Useful commands
+- Create PR with CLI: `git push -u origin <branch>` and `gh pr create --base main --head <branch> --draft`
+- Amend last commit message: `git commit --amend -m "type: subject"`
+- Interactive rebase: `git rebase -i origin/main` + `git push --force-with-lease`
+
+---
+
+## 10) Ideal summary
+- Templates for Issues and PRs (present in `.github/`)
+- Mandatory PR checklist (tests, linter, docs)
+- Squash-and-merge by default
+- CI checks + required review (or CODEOWNERS)
+- Language note: English is the default (types in English, subjects/body/footers in English)
+
+---


### PR DESCRIPTION
* docs(processes): add issue template and processs docs

---

## Summary
Add a Issue template, documentation of the workflow for adding a new docs file, and translating the system root files for english

## Changes
- docs/processes.md
- .github/ISSUE_TEMPLATE
- README.md
- CONTRIBUTING.md
- SECURITY.md
- CODE_OF_CONDUCT.md


## Motivation
This will guide people through the pipeline for contributing with this repo.

## How to test

1. `git checkout features/7-workflow`
2. Manual check: describe UI/CLI steps if applicable

## Checklist
- [ ] Tests added / updated
- [ ] Linter passes locally
- [ ] Documentation updated (`docs/` and `README.md`)
- [ ] CI passed

## Reviewers / Assignees
- Request review from: `@pedroiff0 `